### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "spryker/cms": "^5.0.0 || ^6.0.0",
     "spryker/glossary": "^3.0.0",
     "spryker/gui": "^3.7.0",
-    "spryker/kernel": "^3.0.0",
+    "spryker/kernel": "^3.4.0",
     "spryker/locale": "^3.0.0",
     "spryker/symfony": "^3.0.0",
     "spryker/twig": "^3.0.0",


### PR DESCRIPTION
The spryker/kernel dependency version is wrong. It has to be at least 3.4.0 because:
`Spryker\Zed\CmsGui\Communication\Form\Glossary\CmsGlossaryFormType` depends on 
`Spryker\Zed\Kernel\Communication\Form\AbstractType`
witch was introduced in that version.